### PR TITLE
Remove unsupported Cloud SQL import user flag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,8 +35,6 @@ steps:
       - |
         _INSTANCE_NAME=dev-mysql-instance
         _DB_NAME=dev_db
-        _DB_USER=devuser
-        _DB_PASS=devpassword
         _SQL_FILE=db/dev/init.sql
         echo "Waiting for Cloud SQL instance to be ready..."
         for i in {1..30}; do
@@ -46,7 +44,7 @@ steps:
           sleep 10
         done
         echo "Cloud SQL instance is ready. Running SQL script..."
-        gcloud sql import sql $$_INSTANCE_NAME $$_SQL_FILE --database=$$_DB_NAME --user=$$_DB_USER --quiet
+        gcloud sql import sql $$_INSTANCE_NAME $$_SQL_FILE --database=$$_DB_NAME --quiet
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary
- fix gcloud SQL import command in Cloud Build

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685471d5faa8832bb2c80eb3812c37e7